### PR TITLE
Treat error code 105 as non-session-expired

### DIFF
--- a/Sources/SynologySwiftKit/Core/Error/SynologyApiError.swift
+++ b/Sources/SynologySwiftKit/Core/Error/SynologyApiError.swift
@@ -45,8 +45,8 @@ struct SynologyApiError: Error, Decodable, Sendable {
     /// 将当前实例转换为统一的 SynologyError
     /// Convert to unified SynologyError
     ///
-    /// - Session 相关错误码（105/106/107/119）→ `.sessionExpired`
-    ///   Session-related codes (105/106/107/119) → `.sessionExpired`
+    /// - Session 相关错误码（106/107/119）→ `.sessionExpired`
+    ///   Session-related codes (106/107/119) → `.sessionExpired`
     /// - 120-149 保留错误码 → `.api`
     ///   Reserved codes 120-149 → `.api`
     /// - 其余错误码通过 `SynologyErrorCode` 获取描述后 → `.api`

--- a/Sources/SynologySwiftKit/Core/Error/SynologyErrorCode.swift
+++ b/Sources/SynologySwiftKit/Core/Error/SynologyErrorCode.swift
@@ -30,7 +30,7 @@ public struct SynologyErrorCode: RawRepresentable, Equatable, Hashable, Sendable
     public static let methodDoesNotExist = SynologyErrorCode(rawValue: 103)
     /// 请求的版本不支持该功能 / The requested version does not support the functionality.
     public static let versionDoesNotSupport = SynologyErrorCode(rawValue: 104)
-    /// 登录会话没有权限 / The logged in session does not have permission.
+    /// 登录会话没有权限（不归类为 sessionExpired）/ The logged in session does not have permission (not classified as sessionExpired).
     public static let sessionPermissionDenied = SynologyErrorCode(rawValue: 105)
     /// 会话超时 / Session timeout.
     public static let sessionTimeout = SynologyErrorCode(rawValue: 106)
@@ -119,7 +119,7 @@ public struct SynologyErrorCode: RawRepresentable, Equatable, Hashable, Sendable
     /// Convert error code to SDK's core error type
     public func toSynologyError() -> SynologyError {
         switch self {
-        case .sessionPermissionDenied, .sessionTimeout, .sessionInterrupted, .invalidSession:
+        case .sessionTimeout, .sessionInterrupted, .invalidSession:
             return .sessionExpired(code: rawValue, message: description)
         case _ where (400...410).contains(rawValue):
             return .auth(code: rawValue, message: description)

--- a/Sources/SynologySwiftKit/Core/Networking/Interceptor/AuthInterceptor.swift
+++ b/Sources/SynologySwiftKit/Core/Networking/Interceptor/AuthInterceptor.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// 职责：
 /// 1. 为运行时请求注入当前会话的 SID/DID (Query 或 Cookie)
-/// 2. 处理 105/106 等会话过期错误
+/// 2. 处理 106/107/119 等会话过期错误
 ///
 /// 说明：
 /// - 常规 API 请求的鉴权统一由该拦截器负责。
@@ -74,7 +74,7 @@ struct AuthInterceptor: RequestInterceptor, @unchecked Sendable {
         guard case let .sessionExpired(code, _) = synologyError else {
             return false
         }
-        return code == 0 || [105, 106, 107, 119].contains(code)
+        return code == 0 || [106, 107, 119].contains(code)
     }
 }
 


### PR DESCRIPTION
### Motivation

- Clarify and correct handling of Synology API error code `105` so it is no longer treated as a session expiration, because `105` represents a permission-denied condition rather than an expired/invalid session.

### Description

- Updated documentation in `SynologyApiError` and `AuthInterceptor` to reflect that session-related codes are now `106/107/119` (removed `105`).
- Changed the `SynologyErrorCode` mapping so `.sessionPermissionDenied` (`105`) is no longer included in the `.sessionExpired` case in `toSynologyError()` and will be handled as an API/auth-related error instead.
- Adjusted `AuthInterceptor.isSessionExpiredError(_:)` to stop treating `105` as a session-expired trigger so `onSessionExpired` is not invoked for permission-denied responses.

### Testing

- Ran `swift build` to verify the project compiles successfully and it completed without errors.
- Ran `swift test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05622bed98832ba175d3d142367d37)