### PR TITLE
feat: 在日志级别后加入 `[SynologySwiftKit]` 标识

### DIFF
--- a/Sources/SynologySwiftKit/Core/Utilities/Logger.swift
+++ b/Sources/SynologySwiftKit/Core/Utilities/Logger.swift
@@ -10,6 +10,7 @@ import OSLog
 /// Backed by `OSLog`, controlled by the `isEnabled` switch (enabled by default).
 public final class Logger {
     private static let osLog = OSLog(subsystem: "me.itwl.SynologySwiftKit", category: "SynologySwiftKit")
+    private static let kitTag = "[SynologySwiftKit]"
     public static var isEnabled = true
 
     private init() {}
@@ -43,6 +44,6 @@ public final class Logger {
     private static func log(_ message: String, type: OSLogType, filePath: String, fileNumber: Int) {
         guard isEnabled else { return }
         let swiftFileName = (filePath as NSString).lastPathComponent
-        os_log("[%{public}@:%{public}d] %{public}@", log: osLog, type: type, swiftFileName, fileNumber, message)
+        os_log("%{public}@ [%{public}@:%{public}d] %{public}@", log: osLog, type: type, kitTag, swiftFileName, fileNumber, message)
     }
 }

--- a/Sources/SynologySwiftKit/DiskStationApi/QuickConnect/QuickConnectClient.swift
+++ b/Sources/SynologySwiftKit/DiskStationApi/QuickConnect/QuickConnectClient.swift
@@ -238,11 +238,11 @@ private extension QuickConnectClient {
         // 根据 quickconnectId 配置缓存的 url
         let key = KeyValueStorageKeys.SYNOLOGY_SERVER_URL(quickConnectId).keyName
         if let synologyServerUrl = keyValueStorage.string(forKey: key) {
-            Logger.info("[SynologySwiftKit][QuickConnect]cached synology server: \(synologyServerUrl)")
+            Logger.info("[QuickConnect] cached synology server: \(synologyServerUrl)")
             return synologyServerUrl
         }
 
-        Logger.info("[SynologySwiftKit][QuickConnect]default synology server: \(SynologySwiftKitConstant.GLOBAL_SYNOLOGY_CONNECT_SERVER)")
+        Logger.info("[QuickConnect] default synology server: \(SynologySwiftKitConstant.GLOBAL_SYNOLOGY_CONNECT_SERVER)")
         return SynologySwiftKitConstant.GLOBAL_SYNOLOGY_CONNECT_SERVER
     }
 


### PR DESCRIPTION
### Motivation
- 统一 SDK 内部日志格式，便于在系统 `[log level]` 后直接识别出是 `SynologySwiftKit` 输出而非继承方或宿主应用的日志。

### Description
- 在 `Sources/SynologySwiftKit/Core/Utilities/Logger.swift` 中新增 `kitTag = "[SynologySwiftKit]"` 并修改 `log` 实现，输出格式由 `"[file:line] message"` 改为 `"[SynologySwiftKit] [file:line] message"`，保持原有文件与行号信息。

### Testing
- 执行 `swift test`，测试未能完成因为环境在拉取依赖 `https://github.com/steventong/SwiftHttpClient` 时遭遇网络代理错误（`CONNECT tunnel failed, response 403`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf91a92fc832b99ac3b643f579418)