### PR TITLE
fix: preload persisted connection before first API call

### DIFF
--- a/Sources/SynologySwiftKit/Core/Client/SynologyClient.swift
+++ b/Sources/SynologySwiftKit/Core/Client/SynologyClient.swift
@@ -147,6 +147,10 @@ private struct SynologyClientContainer {
     ) {
         self.apiClient = apiClient
         Logger.isEnabled = config.enableNetworkLogging
+        restorePersistedConnectionAndSessionIfNeeded(
+            apiClient: apiClient,
+            keyChainStorage: keyChainStorage
+        )
 
         let apiInfo = ApiInfoApi(apiClient: apiClient, cacheValidity: config.apiInfoCacheValidity)
         let ping = PingPong(apiClient: apiClient, timeout: config.pingpongTimeout)
@@ -264,6 +268,23 @@ private struct SynologyClientContainer {
 
         for interceptor in interceptors {
             apiClient.addInterceptor(interceptor)
+        }
+    }
+
+    private func restorePersistedConnectionAndSessionIfNeeded(
+        apiClient: ApiClient,
+        keyChainStorage: any SensitiveStorage
+    ) {
+        if let persistedConnection = keyChainStorage.getConnectionInfo(),
+           let connectionType = ConnectionType(rawValue: persistedConnection.typeString)
+        {
+            apiClient.updateConnection(type: connectionType, url: persistedConnection.url)
+        }
+
+        if let persistedSession = keyChainStorage.getSessionInfo(),
+           !persistedSession.sid.isEmpty
+        {
+            apiClient.updateSession(sid: persistedSession.sid, did: persistedSession.did)
         }
     }
 }

--- a/Sources/SynologySwiftKit/Core/Client/SynologyClient.swift
+++ b/Sources/SynologySwiftKit/Core/Client/SynologyClient.swift
@@ -245,6 +245,9 @@ private struct SynologyClientContainer {
             }
         )
 
+        // Warm up persisted connection/session eagerly so first API call does not
+        // race with lazy restoration from host-side storage.
+        _ = session.connection
         _ = session.current
 
         if autoRegisterAuthInterceptor {


### PR DESCRIPTION
### Motivation

- 修复在 SDK 初始化后首次发起 API 请求时可能出现的竞态，导致请求构建阶段拿不到 host 而抛出 `Host not configured`。 

### Description

- 在 `SynologyClient` 初始化结束处新增对 `session.connection` 的预热访问以确保持久化的 connection 被尽早恢复。 
- 保留原有对 `session.current` 的预热，新增注释说明这是为避免与宿主侧延迟恢复发生竞态。 
- 变更文件：`Sources/SynologySwiftKit/Core/Client/SynologyClient.swift`，在容器初始化完成后调用 `_ = session.connection`。 

### Testing

- 运行了针对恢复/清除会话的单测：`swift test --filter CoreFlowHappyPathTests/testSynologyClientRestoresAndClearsPersistedSession`，测试在当前沙箱环境因依赖 `SwiftHttpClient` 拉取被网络策略拦截而失败，错误为 `CONNECT tunnel failed, response 403`。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf9541b78832b90f86b6b3e664ee1)