### PR TITLE
Fix initializer self-use in SynologyClientContainer

### DIFF
--- a/Sources/SynologySwiftKit/Core/Client/SynologyClient.swift
+++ b/Sources/SynologySwiftKit/Core/Client/SynologyClient.swift
@@ -147,7 +147,7 @@ private struct SynologyClientContainer {
     ) {
         self.apiClient = apiClient
         Logger.isEnabled = config.enableNetworkLogging
-        restorePersistedConnectionAndSessionIfNeeded(
+        Self.restorePersistedConnectionAndSessionIfNeeded(
             apiClient: apiClient,
             keyChainStorage: keyChainStorage
         )
@@ -159,7 +159,8 @@ private struct SynologyClientContainer {
         let audioStationClient = AudioStationClient(apiClient: apiClient, keyValueStorage: keyValueStorage)
         self.audioStation = audioStationClient
         self.files = FileStationClient(apiClient: apiClient)
-        self.auth = AuthClient(apiClient: apiClient, keyChainStorage: keyChainStorage)
+        let authClient = AuthClient(apiClient: apiClient, keyChainStorage: keyChainStorage)
+        self.auth = authClient
 
         let quickConnect = QuickConnectClient(
             apiClient: apiClient,
@@ -187,13 +188,13 @@ private struct SynologyClientContainer {
             pingpong: ping,
             audioStationApi: audioStationClient,
             apiInfoApi: apiInfo,
-            authApi: auth,
+            authApi: authClient,
             keyChainStorage: keyChainStorage
         )
         let userLogin = SynologyUserLogin(
             apiInfoApi: apiInfo,
             apiClient: apiClient,
-            authApi: auth,
+            authApi: authClient,
             audioStationApi: audioStationClient,
             connectionChecker: checkConnection,
             keyChainStorage: keyChainStorage
@@ -271,7 +272,7 @@ private struct SynologyClientContainer {
         }
     }
 
-    private func restorePersistedConnectionAndSessionIfNeeded(
+    private static func restorePersistedConnectionAndSessionIfNeeded(
         apiClient: ApiClient,
         keyChainStorage: any SensitiveStorage
     ) {


### PR DESCRIPTION
### Motivation
- Prevent potential use of `self` (instance methods/properties) before all stored properties are initialized in `SynologyClientContainer` initializer.

### Description
- Convert `restorePersistedConnectionAndSessionIfNeeded` from an instance method to a `private static` helper and call it via `Self.restorePersistedConnectionAndSessionIfNeeded(...)` to avoid early instance access.
- Create a local `authClient` variable, assign it to `self.auth` after construction, and use `authClient` for dependency wiring to avoid implicit early `self` references.
- Update places that previously referenced `auth` during initialization to use the new `authClient` local variable.

### Testing
- Ran `swift test` and it failed due to dependency fetch failure caused by network/proxy restrictions when accessing `https://github.com/steventong/SwiftHttpClient/` (CONNECT tunnel failed, response 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d13d6e8ac832b94a1953822156de8)