### PR TITLE
Add test for AlbumApi.list contract and update AudioStation usage example

### DIFF
--- a/Sources/SynologySwiftKit/DiskStationApi/AudioStation/Apis/AlbumApi.swift
+++ b/Sources/SynologySwiftKit/DiskStationApi/AudioStation/Apis/AlbumApi.swift
@@ -42,4 +42,5 @@ public final class AlbumApi {
         let result: AlbumListResult = try await apiClient.request(api)
         return SynologyPage(total: result.total, items: result.albums)
     }
+
 }

--- a/Sources/SynologySwiftKit/DiskStationApi/AudioStation/AudioStationClient.swift
+++ b/Sources/SynologySwiftKit/DiskStationApi/AudioStation/AudioStationClient.swift
@@ -17,7 +17,13 @@ import Foundation
 /// let audioStation = AudioStationClient(apiClient: client.apiClient)
 /// let page = try await audioStation.pins.list()
 /// let items = page.items
-/// let songs = try await audioStation.songs.list(limit: 100, offset: 0)
+/// let recentAlbums = try await audioStation.albums.list(
+///     limit: 50,
+///     offset: 0,
+///     libraryScope: .shared,
+///     includeFields: "avg_rating",
+///     sort: SynologySortDescriptor(field: "time", direction: .descending)
+/// )
 /// ```
 public final class AudioStationClient {
 

--- a/Tests/SynologySwiftKitTests/AudioStationThinApiTests.swift
+++ b/Tests/SynologySwiftKitTests/AudioStationThinApiTests.swift
@@ -80,6 +80,44 @@ final class AudioStationThinApiTests: XCTestCase {
         XCTAssertEqual(folderResult.total, 1)
     }
 
+    func testAlbumApiListCanMatchRecentlyAddedAlbumEndpointContract() async throws {
+        let apiClient = MockApiClient()
+        apiClient.requestHandler = { endpoint in
+            XCTAssertEqual(endpoint.apiName, SynologyApi.AudioStation.ALBUM.name)
+            XCTAssertEqual(endpoint.method, "list")
+            XCTAssertEqual(endpoint.version, 3)
+            XCTAssertEqual(endpoint.httpMethod, .post)
+            XCTAssertEqual(endpoint.parameters["limit"]?.stringValue, "50")
+            XCTAssertEqual(endpoint.parameters["offset"]?.stringValue, "0")
+            XCTAssertEqual(endpoint.parameters["library"]?.stringValue, "shared")
+            XCTAssertEqual(endpoint.parameters["sort_by"]?.stringValue, "time")
+            XCTAssertEqual(endpoint.parameters["sort_direction"]?.stringValue, "desc")
+            XCTAssertEqual(endpoint.parameters["additional"]?.stringValue, "avg_rating")
+
+            return AlbumListResult(offset: 0, total: 1, albums: [
+                Album(
+                    name: "Recent Album",
+                    artist: "Artist",
+                    albumArtist: "Album Artist",
+                    displayArtist: "Display",
+                    year: 2025,
+                    additional: AlbumAdditional(avgRating: AlbumAvgRating(rating: 4))
+                )
+            ])
+        }
+
+        let result = try await AlbumApi(apiClient: apiClient).list(
+            limit: 50,
+            offset: 0,
+            libraryScope: .shared,
+            includeFields: "avg_rating",
+            sort: SynologySortDescriptor(field: "time", direction: .descending)
+        )
+        XCTAssertEqual(result.total, 1)
+        XCTAssertEqual(result.items.first?.name, "Recent Album")
+        XCTAssertEqual(apiClient.requestedEndpoints.count, 1)
+    }
+
     func testLyricsApiSupportsGetAndSearch() async throws {
         let apiClient = MockApiClient()
         let lyricsResult = try JSONDecoder().decode(LyricsResult.self, from: makeJSONData(["lyrics": "hello world"]))


### PR DESCRIPTION
### Motivation

- Ensure `AlbumApi.list` can call the recently added/contracted endpoint parameters (sorting by `time` and requesting `avg_rating`) and that the client constructs the request correctly.
- Improve the `AudioStationClient` usage example to demonstrate listing recent albums with `libraryScope`, `additional` fields, and a `SynologySortDescriptor`.

### Description

- Added `testAlbumApiListCanMatchRecentlyAddedAlbumEndpointContract` in `AudioStationThinApiTests.swift` to validate that `AlbumApi.list` sends `limit`, `offset`, `library`, `sort_by`, `sort_direction`, and `additional` parameters and properly decodes an `AlbumListResult` with `AlbumAdditional.avgRating`.
- Updated the example usage comment in `AudioStationClient.swift` to show calling `audioStation.albums.list` with `limit`, `offset`, `libraryScope`, `includeFields`, and `sort` parameters.
- Minor formatting/whitespace adjustment in `AlbumApi.swift` to keep file formatting consistent.

### Testing

- Ran the unit test `AudioStationThinApiTests.testAlbumApiListCanMatchRecentlyAddedAlbumEndpointContract` which succeeded. 
- Ran the `AudioStationThinApiTests` suite and the test assertions passed when executing the mock `ApiClient` handlers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4e5ae8cc832bba969f1aadf721f9)